### PR TITLE
Upgrade Eslint v3 -> v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-fyndiq",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "ESLint config for Fyndiq projects",
   "main": "eslint.js",
   "keywords": [
@@ -12,20 +12,20 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "eslint-config-airbnb": "^14.1.0"
+    "eslint-config-airbnb": "^15.1.0"
   },
   "peerDependencies": {
     "babel-eslint": "^7.1.1",
-    "eslint": "^3.15.0",
+    "eslint": "^4.3.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-react": "^6.10.0",
-    "eslint-plugin-jsx-a11y": "^4.0.0"
+    "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-react": "^7.1.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",
-    "eslint": "^3.15.0",
+    "eslint": "^4.3.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^4.0.0",
-    "eslint-plugin-react": "^6.10.0"
+    "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-react": "^7.1.0"
   }
 }


### PR DESCRIPTION
## Overview

This PR upgrades the `eslint` dependency to `v4`.

## How to test

- `npm i` shouldn't give any error or warning regarding packages that require a `peerDependency` of another package in a specific version.